### PR TITLE
Review feedback with issue extension. 

### DIFF
--- a/ckanext/datasetapproval/blueprints.py
+++ b/ckanext/datasetapproval/blueprints.py
@@ -95,12 +95,12 @@ def _make_action(package_id, action='reject'):
         message = '[email] Failed to sent notification to the editor: {}'
         log.critical(message.format(package_id))
     
-    msg = 'Dataset "{0}" {1}'.format(data_dict['title'], states[action])
+    msg = 'Dataset "{0}" {1}.'.format(data_dict['title'], states[action])
     if action == 'approve':
         toolkit.h.flash_success(msg)
     else:
         toolkit.h.flash_error(msg)
-    return toolkit.redirect_to(controller='dataset', action='read', id=data_dict['name'])
+        return toolkit.redirect_to(controller='issues', action='new', dataset_id=package_id)
 
 
 approveBlueprint.add_url_rule('/dataset-publish/<id>/approve', view_func=approve)

--- a/ckanext/datasetapproval/templates/package/read.html
+++ b/ckanext/datasetapproval/templates/package/read.html
@@ -19,7 +19,12 @@
       {% endif %}
     </div>
   {% elif c.pkg_dict.approval_state  == 'rejected' %}
-    {% if not h.is_admin(c.user)%}
+    {% if h.is_admin(c.user, c.pkg_dict.owner_org) %}
+    <div class="alert alert-danger" role="alert">
+      <p>{% trans %}Dataset was rejected.{% endtrans %}</p>
+    </div>
+    {% endif %}
+    {% if not h.is_admin(c.user, c.pkg_dict.owner_org)%}
     <div class="alert alert-danger" role="alert">
       <p>{% trans %}Dataset was rejected by administrator.{% endtrans %}</p>
     </div>


### PR DESCRIPTION
Fixes for https://github.com/FCSCOpendata/ckanext-fcscopendata/issues/70
This change includes the following extended feature on the ckanext_issue extension.

- Rejecting the dataset will redirect the user to a new issue and create UI
- Approval will  close all the open issues for the dataset
- Flash message improved for editor/admin user when the dataset is rejected. 
